### PR TITLE
Correct session storage issue

### DIFF
--- a/cypress/e2e/bstack-store/tests/checkout_process.cy.ts
+++ b/cypress/e2e/bstack-store/tests/checkout_process.cy.ts
@@ -6,6 +6,7 @@ import Checkout from "../pages/Checkout"
 describe('completes checkout', () => {
     before(() => {
         cy.clearAllSessionStorage()
+        Cypress.session.clearAllSavedSessions()
     })
     beforeEach(() => {
         api_sign_in_test_user('demouser')

--- a/cypress/e2e/bstack-store/utils/Sessions.ts
+++ b/cypress/e2e/bstack-store/utils/Sessions.ts
@@ -10,7 +10,9 @@ export function api_sign_in_test_user(username: string): void {
                     password: user.password
                 }
             }).then(() => {
-                window.sessionStorage.setItem('username', user.userName)
+                cy.window().then((win) => {
+                    win.sessionStorage.setItem('username', user.userName)
+                })
             })
         })
     


### PR DESCRIPTION
- The api_sign_in_test_user method was creating the user session through the window object directly, this caused problems since it happened outside the browser context Cypress actually controls.
- Moved the setItem() call to cy.window rather than the window object directly